### PR TITLE
Global unique node names

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -313,7 +313,9 @@ module Tree
     def add(child, at_index = -1)
       raise ArgumentError, "Attempting to add a nil node" unless child # Only handles the immediate child scenario
       raise ArgumentError, "Attempting add node to itself" if self == child
-      raise "Child #{child.name} already added!" if @children_hash.has_key?(child.name)
+
+      # Lazy mans unique test, won't test if children of child are unique in this tree too.
+      self.root.each { |node| raise "Child #{child.name} already added!" if node.name == child.name }
 
       if insertion_range.include?(at_index)
         @children.insert(at_index, child)

--- a/test/test_tree.rb
+++ b/test/test_tree.rb
@@ -1115,10 +1115,8 @@ module TestTree
       assert_raise(ArgumentError) {root << root}
 
       # And now a scenario where the node addition is done down the hierarchy
-      # @todo This scenario is not yet fixed.
       child =  Tree::TreeNode.new("child")
-      root << child << root
-      # puts root                 # This will throw a stack trace
+      assert_raise(RuntimeError) { root << child << root }
     end
 
     # Test whether the tree_leaf method works correctly
@@ -1130,6 +1128,14 @@ module TestTree
       leafs.each {|leaf| leaf.remove_from_parent!}
       parents.each {|parent| assert(parent.is_leaf?) if not parent.has_children?}
 
+    end
+
+    # Test if node names are really unique in the whole tree
+    def test_unique_node_names
+      setup_test_tree
+
+      assert_raise(RuntimeError) { @root << @child1 }
+      assert_raise(RuntimeError) { @root.first_child << @child2 }
     end
 
   end


### PR DESCRIPTION
While using RubyTree at work I noticed that the node names, though the documentation states "The node name is expected to be unique within the tree.", are not unique if you add an already added node/name to another child. There are several ways to fix this, the easiest implementation, is to check if the tree, where the child is added too, already contains a node with this name.

Because I'm not allowed to spend too much worktime on open source projects I stuck with the simple implementation I mentioned and hope that this is of any use to you anyway. While testing, the "add node to self as child" case was fixed too so I changed the test likewise.

Adding a node might still be exploitable by something like this, I hope you get the idea, could happen anytime you add a node or merge two trees:

``` ruby
@root     = Tree::TreeNode.new('root', "Root node")
@child1   = Tree::TreeNode.new('child1', '1st child')
@child2   = Tree::TreeNode.new('child2', '2nd child')
@conflict = Tree::TreeNode.new('conflict', 'Should do problems')

@child1 << @conflict # should work because @conflict is not in root-tree
@child2 << @conflict # same here.

@root << @child1 # no problem so far
@root << @child2 # now two nodes with the name 'conflict' exist in root tree
```

Thanks a lot for RubyTree and best regards, ysf :)
