### PR TITLE
Update tree.rb for customizable print tree

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -806,7 +806,7 @@ module Tree
     #
     # @param [Integer] level The indentation level (4 spaces) to start with.
     # @param [Proc] block optional block to use for rendering 
-    def print_tree(level = 0, block = ->(node, prefix) { puts "#{prefix} #{node.name}" })
+    def print_tree(level = 0, block = lambda { |node, prefix|  puts "#{prefix} #{node.name}" })
       prefix = ''
       if is_root?
         prefix << '*'


### PR DESCRIPTION
I needed some customizable code to print a tree and the default print_tree code was a perfect starting point.
The default is to render as before this patch

example of use:

```
tree.root_node.print_tree 0, method(:print_node)
def print_node(node, prefix)
  # your code
end
```

As I'm not a expert, comments and advices are welcome.
