### PR TITLE
adding a max_depth to the tree printing

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -805,7 +805,7 @@ module Tree
     # Pretty prints the (sub)tree rooted at this node.
     #
     # @param [Integer] level The indentation level (4 spaces) to start with.
-    def print_tree(level = 0)
+    def print_tree(max_depth = nil, level = 0)
       if is_root?
         print "*"
       else
@@ -817,6 +817,8 @@ module Tree
       end
 
       puts " #{name}"
+      
+      return unless max_depth.nil? || level < max_depth
 
       children { |child| child.print_tree(level + 1) if child } # Child might be 'nil'
     end


### PR DESCRIPTION
To help debug rather large trees. I ran into a need for this with a depth of 25. 

I also saved that tree as json, I had to add a :max_nesting option to the "as_json" call. Not sure if that's something you want so I'm not including it in the pull request, but figured it was worth mentioning.
