### PR TITLE
Correctly recurse print_tree method

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -849,7 +849,7 @@ module Tree
 
       return unless max_depth.nil? || level < max_depth # Exit if the max level is defined, and reached.
 
-      children { |child| child.print_tree(level + 1, block) if child } # Child might be 'nil'
+      children { |child| child.print_tree(level + 1, max_depth, block) if child } # Child might be 'nil'
     end
 
   end


### PR DESCRIPTION
When recursing the print_tree method, max_depth isn't passed in before the block, causing the block to be passed as max_depth which then results in an error trying to compare a fixnum to a block. This PR passes in all the arguments as expected.

There are currently no working tests for print_tree so I didn't modify or add any, let me know if there is more to be done for this to get merged. 

Thanks!
