### PR TITLE
Allow a node to be renamed

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -93,7 +93,7 @@ module Tree
 
     # @!group Core Attributes
 
-    # @!attribute [r] name
+    # @!attribute [rw] name
     #
     # Name of this node.  Expected to be unique within the tree.
     #
@@ -105,8 +105,12 @@ module Tree
     # retain unique names within the tree structure, and use the
     # +content+ attribute for any non-unique node requirements.
     #
+    # If you want to change the name, you probably want to call +rename+
+    # instead.
+    #
     # @see content
-    attr_reader   :name
+    # @see rename
+    attr_accessor   :name
 
     # @!attribute [rw] content
     # Content of this node.  Can be +nil+.  Note that there is no
@@ -381,6 +385,35 @@ module Tree
 
     private :insertion_range
 
+    # Renames the node and updates the parent's reference to it
+    #
+    # @param [Object] name Name of the node.  Conventional usage is to pass a String
+    #   (Integer names may cause *surprises*)
+    #
+    # @return [Object] The old name
+    def rename(new_name)
+      old_name = @name
+
+      if is_root?
+        @name = new_name
+      else
+        @parent.rename_child @name, new_name
+      end
+
+      old_name
+    end
+
+    # Renames the specified child node 
+    #
+    # @param [Object] name old Name of the node. Conventional usage is to pass
+    #   a String (Integer names may cause *surprises*)
+    #
+    # @param [Object] name new Name of the node. Conventional usage is to pass
+    #   a String (Integer names may cause *surprises*)
+    def rename_child(old_name, new_name)
+      @children_hash[new_name] = @children_hash.delete(old_name)
+      @children_hash[new_name].name= new_name
+    end
 
     # Replaces the specified child node with another child node on this node.
     #

--- a/test/test_tree.rb
+++ b/test/test_tree.rb
@@ -1586,6 +1586,27 @@ module TestTree
       assert_raise(TypeError) { @root.merge!('ROOT') }
     end
 
+    def test_name_accessor
+      setup_test_tree
+
+      assert_equal 'ROOT', @root.name, "Name should be 'ROOT'"
+
+      @root.name = 'ROOT2'
+
+      assert_equal 'ROOT2', @root.name, "Name should be 'ROOT2'"
+    end
+
+    def test_renam
+      setup_test_tree
+
+      @root.rename 'ALT_ROOT'
+      assert_equal('ALT_ROOT', @root.name, "Name should be 'ALT_ROOT'")
+
+      @child1.rename 'ALT_Child1'
+      assert_equal('ALT_Child1', @child1.name)
+      assert_equal('ALT_Child1', @child1.name, "Name should be 'ALT_Child1'")
+      assert_equal(@child1, @root['ALT_Child1'], 'Should be able to access from parent using new name')
+    end
   end
 end
 


### PR DESCRIPTION
This PR will allow you to `#rename` a node in place. I took a shot at setting up the documentation but it probably needs to be cleaned up. Feel free to let me know if you would like any changes made so that you are happy merging it.

Do note that I made the name attribute read/write as opposed to read. I had to make it writable and add the rename method because updating a node's name also involves updating information on the parent node if it has one. So I added the `rename_child` method on the parent that will update it's children hash as well as call `#name` on the child. By separating out the setting of the instance variable and the logic of communicating with the parent, we avoid a stack overflow as a parent updates the name of the child node which then tries to update the children_hash key on the parent, and so on and so on.

Thanks!
