### PR TITLE
Add MRI 2.2.0 to Travis configuration

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,1 @@
----
-BUNDLE_DISABLE_SHARED_GEMS: '1'
+--- {}

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,1 +1,2 @@
---- {}
+---
+BUNDLE_DISABLE_SHARED_GEMS: '1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.1.2
   - 2.1.3
   - 2.1.4
+  - 2.2.0
 #  - ruby-head    # The latest Ruby, whatever version it happens to be.
   - jruby-18mode
   - jruby-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :development, :test do
   gem "rake", "~> 10.1"
   gem "coveralls", ">= 0.7", :require => false, :platforms => :mri_21
+  gem 'test-unit', '~> 3.0', :require => false, :platforms => :ruby_22
 end
 
 # Local Variables:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     json (1.8.1)
     mime-types (2.4.3)
     multi_json (1.10.1)
+    power_assert (0.2.2)
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
@@ -34,6 +35,8 @@ GEM
     structured_warnings (0.1.4)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
+    test-unit (3.0.9)
+      power_assert
     thor (0.18.1)
     tins (0.13.2)
     yard (0.8.7.6)
@@ -48,4 +51,5 @@ DEPENDENCIES
   rdoc (~> 4.1)
   rtagstask (~> 0.0)
   rubytree!
+  test-unit (~> 3.0)
   yard (~> 0.8)

--- a/rubytree.gemspec
+++ b/rubytree.gemspec
@@ -73,6 +73,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc'            , '~> 4.1'
   s.add_development_dependency 'yard'            , '~> 0.8'
   s.add_development_dependency 'rtagstask'       , '~> 0.0'
+  s.add_development_dependency 'test-unit'       , '~> 3.0'
 
   s.post_install_message = <<-EOF
     ========================================================================


### PR DESCRIPTION
If you are ok with officially supporting MRI 2.2.0 this PR adds it to the travis build as a required pass.