### PR TITLE
Fixed unexpected behaviour Tree::TreeNode#detached_copy for subclasses.

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -230,7 +230,7 @@ module Tree
     #
     # @return [Tree::TreeNode] A copy of this node.
     def detached_copy
-      Tree::TreeNode.new(@name, @content ? @content.clone : nil)
+      self.class.new(@name, @content ? @content.clone : nil)
     end
 
     # Returns a copy of entire (sub-)tree from this node.

--- a/test/test_subclassed_node.rb
+++ b/test/test_subclassed_node.rb
@@ -64,7 +64,7 @@ module TestTree
 
     end
 
-    def test_subclassed_detached_copy
+    def test_subclassed_detached_copy_is_same_class
       root = MyNode.new("Root")
       assert_equal(MyNode, root.detached_copy.class)
     end

--- a/test/test_subclassed_node.rb
+++ b/test/test_subclassed_node.rb
@@ -64,6 +64,11 @@ module TestTree
 
     end
 
+    def test_subclassed_detached_copy
+      root = MyNode.new("Root")
+      assert_equal(MyNode, root.detached_copy.class)
+    end
+
   end
 end
 


### PR DESCRIPTION
```ruby
binary_tree = Tree::BinaryTreeNode.new("Hi")
binary_tree.class # => Tree::BinaryTreeNode

copy = binary_tree.detached_copy
copy.class # => Tree::TreeNode
```

My fix makes sure copies of subclasses of Tree::TreeNode have the same class as the node that is copied.