### PR TITLE
Allow print_tree for non-root nodes

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -934,7 +934,7 @@ module Tree
     # @param [Integer] max_depth optional maximum depth at which the printing
     #                            with stop.
     # @param [Proc] block optional block to use for rendering
-    def print_tree(level = 0, max_depth = nil,
+    def print_tree(level = node_depth, max_depth = nil,
                    block = lambda { |node, prefix|
                      puts "#{prefix} #{node.name}" })
       prefix = ''


### PR DESCRIPTION
Right now print_tree for non-root nodes fails with something like
```
/home/user/.rvm/gems/ruby-2.2.2/gems/rubytree-0.9.6/lib/tree.rb:946:in `*': negative argument (ArgumentError)
	from /home/user/.rvm/gems/ruby-2.2.2/gems/rubytree-0.9.6/lib/tree.rb:946:in `print_tree'
```

because of default level = 0.
If we'll set level = node_depth, partial trees can be printed without issues.