### PR TITLE
removing broken badge and markup typo

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,5 +1,3 @@
-# @markup rdoc
-
 = History of Changes
 
 === 0.9.5 / 2015-05-30

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Dependency Status](https://gemnasium.com/evolve75/RubyTree.png)](https://gemnasium.com/evolve75/RubyTree)
 [![Code Climate](https://codeclimate.com/github/evolve75/RubyTree.png)](https://codeclimate.com/github/evolve75/RubyTree)
 [![Coverage Status](https://coveralls.io/repos/evolve75/RubyTree/badge.png)](https://coveralls.io/r/evolve75/RubyTree)
-[![githalytics.com alpha](https://cruel-carlota.pagodabox.com/473b881f1075bf9f255f0181dde6068f)](http://githalytics.com/evolve75/RubyTree)
+[![githalytics.com alpha](https://cruel-carlota.gopagoda.com/473b881f1075bf9f255f0181dde6068f)](http://githalytics.com/evolve75/RubyTree)
 
 ## DESCRIPTION: ##
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![Dependency Status](https://gemnasium.com/evolve75/RubyTree.png)](https://gemnasium.com/evolve75/RubyTree)
 [![Code Climate](https://codeclimate.com/github/evolve75/RubyTree.png)](https://codeclimate.com/github/evolve75/RubyTree)
 [![Coverage Status](https://coveralls.io/repos/evolve75/RubyTree/badge.png)](https://coveralls.io/r/evolve75/RubyTree)
-[![githalytics.com alpha](https://cruel-carlota.gopagoda.com/473b881f1075bf9f255f0181dde6068f)](http://githalytics.com/evolve75/RubyTree)
 
 ## DESCRIPTION: ##
 


### PR DESCRIPTION
As per http://githalytics.tumblr.com/post/52320313765/change-of-our-hosting-domain-name the githalytics domain changed but when I tried it, it still did not load. I think that they are defunct, so I removed the badge. It may be possible to use
https://github.com/igrigorik/ga-beacon or https://github.com/blog/1672-introducing-github-traffic-analytics for the same purpose. 

I removed an extra line at the top of History.rdoc that looked like 
![screen shot 2015-08-05 at 5 54 32 pm](https://cloud.githubusercontent.com/assets/578159/9101385/0cebe3ac-3b9b-11e5-87b0-996d504eaf2f.png)
