### PR TITLE
Allow json for current ruby versions 

### DIFF
--- a/rubytree.gemspec
+++ b/rubytree.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
   s.rdoc_options         = ["--title", "Rubytree Documentation", "--quiet"]
 
   s.add_runtime_dependency 'structured_warnings' , '~> 0.2'
-  s.add_runtime_dependency 'json'                , '~> 1.8'
+  s.add_runtime_dependency 'json'                ,  ['>= 1.8', '< 3.0']
 
   # Note: Rake is added as a development and test dependency in the Gemfile.
   s.add_development_dependency 'bundler'         , '~> 1.7'


### PR DESCRIPTION
I updated the gemspec to allow higher json versions than 1.8.