### PR TITLE
Unclonable content

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -235,7 +235,13 @@ module Tree
     #
     # @return [Tree::TreeNode] A copy of this node.
     def detached_copy
-      self.class.new(@name, @content ? @content.clone : nil)
+      cloned_content =
+        begin
+          @content ? @content.clone : nil
+        rescue TypeError
+          @content
+        end
+      self.class.new(@name, cloned_content)
     end
 
     # Returns a copy of entire (sub-)tree from this node.

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -237,7 +237,7 @@ module Tree
     def detached_copy
       cloned_content =
         begin
-          @content ? @content.clone : nil
+          @content && @content.clone
         rescue TypeError
           @content
         end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -103,4 +103,17 @@ describe Tree do
 
     it_behaves_like "any cloned node"
   end
+
+  context "#detached_copy", "with unclonable content" do
+    before(:each) do
+      @tree = Tree::TreeNode.new("A", :unclonable_content)
+      @clone = @tree.detached_copy
+    end
+
+    it "keeps the content" do
+      expect(@clone.content).to be @tree.content
+    end
+
+    it_behaves_like "any cloned node"
+  end
 end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -71,4 +71,36 @@ describe Tree do
 
     it_behaves_like "any detached node"
   end
+
+  shared_examples_for "any cloned node" do
+    it "is equal to the original" do
+      expect(@clone).to eq @tree
+    end
+    it "is not identical to the original" do
+      expect(clone).not_to be @tree
+    end
+  end
+
+  context "#detached_copy", "without content" do
+    before(:each) do
+      @tree = Tree::TreeNode.new("A", nil)
+      @clone = @tree.detached_copy
+    end
+
+    it_behaves_like "any cloned node"
+  end
+
+  context "#detached_copy", "with clonable content" do
+    before(:each) do
+      @tree = Tree::TreeNode.new("A", "clonable content")
+      @clone = @tree.detached_copy
+    end
+
+    it "makes a clone of the content" do
+      expect(@clone.content).to eq @tree.content
+      expect(@clone.content).not_to be @tree.content
+    end
+
+    it_behaves_like "any cloned node"
+  end
 end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -116,4 +116,17 @@ describe Tree do
 
     it_behaves_like "any cloned node"
   end
+
+  context "#detached_copy", "with false as content" do
+    before(:each) do
+      @tree = Tree::TreeNode.new("A", false)
+      @clone = @tree.detached_copy
+    end
+
+    it "keeps the content" do
+      expect(@clone.content).to be @tree.content
+    end
+
+    it_behaves_like "any cloned node"
+  end
 end


### PR DESCRIPTION
Examples like this

* `TreeNode.new('name', :symbol).detached_copy`
* `TreeNode.new('name', 5).detached_copy`
* `TreeNode.new('name', true).detached_copy`

currently fail, with attempt to clone an unclonable object raising `TypeError`. This PR adds handling of unclonable content.