### PR TITLE
Fixes #70 - Refactor protected call within method_missing

### DIFF
--- a/lib/tree/utils/camel_case_method_handler.rb
+++ b/lib/tree/utils/camel_case_method_handler.rb
@@ -58,8 +58,6 @@ module Tree::Utils
         end
       end
 
-      protected
-
       # @!visibility private
       # Convert a CamelCasedWord to a underscore separated camel_cased_word.
       #
@@ -74,6 +72,7 @@ module Tree::Utils
         word.downcase!
         word
       end
+      protected :to_snake_case
 
     end # self.included
   end


### PR DESCRIPTION
Ruby 2.7 now emits a warning for non-explicit visibility calls within methods.