### PR TITLE
Allow comparison and serialization with sub-classes.

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -291,7 +291,7 @@ module Tree
         content     = Marshal.load(node_hash[:content])
 
         if parent_name
-          nodes[name] = current_node = Tree::TreeNode.new(name, content)
+          nodes[name] = current_node = self.class.new(name, content)
           nodes[parent_name].add current_node
         else
           # This is the root node, hence initialize self.
@@ -952,7 +952,7 @@ module Tree
     #                   this node is a 'predecessor'. Returns 'nil' if the other
     #                   object is not a 'Tree::TreeNode'.
     def <=>(other)
-      return nil if other == nil || other.class != Tree::TreeNode
+      return nil if other == nil || !other.is_a?(Tree::TreeNode)
       self.name <=> other.name
     end
 

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -11,6 +11,7 @@ require 'rspec'
 require 'spec_helper'
 
 describe Tree do
+  class SpecializedTreeNode < Tree::TreeNode; end
 
   shared_examples_for 'any detached node' do
     it 'should not equal "Object.new"' do
@@ -70,5 +71,49 @@ describe Tree do
     end
 
     it_behaves_like 'any detached node'
+  end
+
+  describe 'comparison' do
+    let(:node1) { Tree::TreeNode.new('a') }
+    let(:node2) { SpecializedTreeNode.new('b') }
+
+    it 'allows comparison of specialized tree nodes' do
+      expect(node1 <=> node2).to be_eql(-1)
+    end
+
+    it 'does not allow comparison with nil' do
+      expect(node1 <=> nil).to be(nil)
+    end
+
+    it 'does not allow comparison with other objects' do
+      expect(node1 <=> 'c').to be(nil)
+    end
+  end
+
+  describe 'serialization' do
+    let(:node1) { SpecializedTreeNode.new('a') }
+    let(:serialized_node1) { Marshal.dump(node1) }
+    let(:node2) { Tree::TreeNode.new('b') }
+    let(:serialized_node2) { Marshal.dump(node2) }
+    let(:tree) do
+      SpecializedTreeNode.new('root').tap do |root|
+        root << node1
+        root << node2
+      end
+    end
+    let(:serialized_tree) { Marshal.dump(tree) }
+
+    it 'parses the serialized specialized tree node correctly (root)' do
+      expect(Marshal.load(serialized_tree)).to be_a(SpecializedTreeNode)
+    end
+
+    it 'parses the serialized specialized tree node correctly (child)' do
+      expect(Marshal.load(serialized_tree).children.first).to \
+        be_a(SpecializedTreeNode)
+    end
+
+    it 'parses the serialized tree node correctly' do
+      expect(Marshal.load(serialized_node2)).to be_a(Tree::TreeNode)
+    end
   end
 end


### PR DESCRIPTION
First things first: Thank you very much for this great gem!

---

**- What is it good for**

With the small changes, we can not inherit the `Tree::TreeNode` class and build specialized trees (with extended functionality) and serialize and compare them correctly. Before the deserialization always forced the children to be of type `Tree::TreeNode`, which drops custom functionality.

**- What I did**

* Added support for correct sub-class (de)serialization
* Improved the comparability, so we allow pure `Tree::TreeNode` instances to be compared with compatible sub-classes
* Added specs for both things

**- A picture of a cute animal (not mandatory but encouraged)**

![Download](https://user-images.githubusercontent.com/2496275/96441666-313d3580-120a-11eb-8b04-5aaa1fe8b421.jpeg)
