### PR TITLE
Added a Github workflow for coveralls.io integration.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service-name: github
+repo_token: 5JHbEro1j0uJyxWvQSF67Ds1U6UPHyOmj

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,51 @@
+# Check the test coverage of the code.
+#
+# This runs as a Github Action.
+#
+# See https://github.com/marketplace/actions/coveralls-github-action
+
+name: Test Coveralls
+on: ["push", "pull_request"]
+
+env:
+  COVERAGE: true
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and bundler dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run Ruby Tests
+        run: bundle exec rake clobber test:coverage
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: ruby-${{ matrix.ruby }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     json (2.6.2)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -54,6 +55,13 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     stringio (3.0.2)
     test-unit (3.5.3)
       power_assert
@@ -75,6 +83,8 @@ DEPENDENCIES
   rubocop-rake (~> 0.0)
   rubocop-rspec (~> 2.0)
   rubytree!
+  simplecov (~> 0.21)
+  simplecov-lcov (~> 0.8)
   test-unit (~> 3.0)
   yard (~> 0.0, >= 0.9.20)
 

--- a/Rakefile
+++ b/Rakefile
@@ -139,18 +139,6 @@ namespace :test do
   task :coverage do
     ruby 'test/run_test.rb'
   end
-
-  begin
-    require 'rcov/rcovtask'
-    Rcov::RcovTask.new(:rcov) do |t|
-      t.libs << 'test'
-      t.test_files = FileList['test/**/test_*.rb']
-      t.verbose = true
-      t.rcov_opts << '--exclude /gems/,/Library/,/usr/,spec,lib/tasks'
-    end
-  rescue LoadError
-    # Oh well. Can't have everything.
-  end
 end
 
 # ................................ Emacs Tags

--- a/rubytree.gemspec
+++ b/rubytree.gemspec
@@ -58,8 +58,6 @@ Gem::Specification.new do |s|
 
   s.require_paths        = ['lib']
 
-  s.test_files           = Dir.glob('test/**/test_*.rb')
-
   s.extra_rdoc_files     = %w[README.md LICENSE.md API-CHANGES.md History.md]
   s.rdoc_options         = ['--title', "Rubytree Documentation: #{s.name}-#{s.version}",
                             '--main', 'README.md',
@@ -76,6 +74,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.0'
   s.add_development_dependency 'rubocop-rake', '~> 0.0'
   s.add_development_dependency 'rubocop-rspec', '~> 2.0'
+  s.add_development_dependency 'simplecov', '~> 0.21'
+  s.add_development_dependency 'simplecov-lcov', '~> 0.8'
   s.add_development_dependency 'test-unit', '~> 3.0'
   s.add_development_dependency 'yard', '~> 0.0', '>= 0.9.20'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,40 @@
 # spec_helper.rb
 #
 # Author:  Anupam Sengupta
-# Time-stamp: <2022-06-19 22:38:14 anupam>
+# Time-stamp: <2022-06-22 13:54:00 anupam>
 #
 # Copyright (C) 2015, 2022 Anupam Sengupta <anupamsg@gmail.com>
 #
 # frozen_string_literal: true
 
 require 'tree'
+
+if ENV['COVERAGE']
+  begin
+    require 'simplecov'
+    require 'simplecov-lcov'
+
+    base_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+    SimpleCov::Formatter::LcovFormatter.config do |cfg|
+      cfg.report_with_single_file = true
+      cfg.lcov_file_name = 'lcov.info'
+      cfg.single_report_path = "#{base_dir}/coverage/lcov.info"
+    end
+
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+      [
+        SimpleCov::Formatter::HTMLFormatter,
+        SimpleCov::Formatter::LcovFormatter
+      ]
+    )
+
+    SimpleCov.start do
+      add_filter '/test'
+      add_filter '/spec'
+      enable_coverage :branch
+    end
+  rescue LoadError => e
+    puts "Could not load simplecov; continuing without code coverage #{e.cause}"
+  end
+end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -3,7 +3,7 @@
 # tree_spec.rb
 #
 # Author:  Anupam Sengupta
-# Time-stamp: <2022-06-20 22:16:11 anupam>
+# Time-stamp: <2022-06-22 13:52:50 anupam>
 # Copyright (C) 2015-2022 Anupam Sengupta <anupamsg@gmail.com>
 #
 # frozen_string_literal: true

--- a/test/run_test.rb
+++ b/test/run_test.rb
@@ -3,7 +3,7 @@
 # run_test.rb:: Run all the tests from the Ruby command line.
 #
 # Author:  Anupam Sengupta
-# Time-stamp: <2022-06-19 22:44:56 anupam>
+# Time-stamp: <2022-06-22 13:54:25 anupam>
 # Copyright (C) 2014, 2022 Anupam Sengupta <anupamsg@gmail.com>
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -42,14 +42,25 @@ $LOAD_PATH.unshift(lib_dir)
 if ENV['COVERAGE']
   begin
     require 'simplecov'
-    require 'coveralls'
+    require 'simplecov-lcov'
 
-    SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+    SimpleCov::Formatter::LcovFormatter.config do |cfg|
+      cfg.report_with_single_file = true
+      cfg.lcov_file_name = 'lcov.info'
+      cfg.single_report_path = "#{base_dir}/coverage/lcov.info"
+    end
+
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+      [
+        SimpleCov::Formatter::HTMLFormatter,
+        SimpleCov::Formatter::LcovFormatter
+      ]
+    )
 
     SimpleCov.start do
-      add_filter '/test/'
-      add_group 'Core Classes', '/lib/.*tree.rb'
-      add_group 'Internal Utilities', '/lib/tree/utils/.*.rb'
+      add_filter '/test'
+      add_filter '/spec'
+      enable_coverage :branch
     end
   rescue LoadError => e
     puts "Could not load simplecov; continuing without code coverage #{e.cause}"


### PR DESCRIPTION
- Added `SimpleCov` for running the test coverage reporting.
- Removed the old `rcov` task. We now use `SimpleCov`.

`SimpleCov` is the package that runs the coverage tests; `coveralls` simply
publishes it to <https://coveralls.io> (which will be done via the Github actions).