### PR TITLE
Fixed the incorrect license in the `gemspec`. Should be `BSD-2-clause`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubytree (2.0.0)
+    rubytree (2.0.1)
       json (~> 2.0, > 2.3.1)
 
 GEM

--- a/lib/tree/version.rb
+++ b/lib/tree/version.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Anupam Sengupta (anupamsg@gmail.com)
 #
-# Copyright (c) 2012-2022 Anupam Sengupta. All rights reserved.
+# Copyright (c) 2012-2023 Anupam Sengupta. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,5 +35,5 @@
 
 module Tree
   # Rubytree Package Version
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/rubytree.gemspec
+++ b/rubytree.gemspec
@@ -3,7 +3,7 @@
 #
 # Author:: Anupam Sengupta (anupamsg@gmail.com)
 #
-# Copyright (c) 2012-2022 Anupam Sengupta. All rights reserved.
+# Copyright (c) 2012-2023 Anupam Sengupta. All rights reserved.
 #
 # frozen_string_literal: true
 
@@ -12,7 +12,7 @@ require File.join(__dir__, '/lib/tree/version')
 Gem::Specification.new do |s|
   s.name                  = 'rubytree'
   s.version               = Tree::VERSION
-  s.license               = 'BSD-3-Clause-Clear'
+  s.license               = 'BSD-2-Clause'
   # NOTE: s.date should NOT be assigned. It is automatically set to pkg date.
   s.platform              = Gem::Platform::RUBY
   s.author                = 'Anupam Sengupta'


### PR DESCRIPTION
Was incorrectly specified as `BSD-3-Clause-Clear.` Should be `BSD-2-clause`, 
as has been used in rest of the code.

For reference, this is the _exact_ license being used:

[BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)