### PR TITLE
[Issue-104] Updated guard clause to include subtypes

### DIFF
--- a/lib/tree/utils/hash_converter.rb
+++ b/lib/tree/utils/hash_converter.rb
@@ -106,7 +106,8 @@ module Tree
 
           root, children = hash.first
 
-          raise ArgumentError, 'Invalid child. Must be nil or hash.' unless [Hash, NilClass].include?(children.class)
+          raise ArgumentError, 'Invalid child. Must be nil or hash.'\
+                                unless [Hash, NilClass].any? { |c| children.is_a? c }
 
           node = new(*root)
           node.add_from_hash(children) unless children.nil?


### PR DESCRIPTION
Updated to check subtypes to be compatible with the Ruby on Rails class `ActiveSupport::HashWithIndifferentAccess`, which is a sub-class of `Hash`