### PR TITLE
Added Readthedocs.org configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   tools:
     ruby: "3.3"    
   commands:
-    - gem install bundler
+    - gem install bundler -v 2.3
     - bundle install
     - rake doc:yard
     - cp -r doc $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,18 +5,18 @@
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
+# Set the version of Ruby and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    ruby: "3.3"
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: doc/conf.py
-
-# We recommend specifying your dependencies to enable reproducible builds:
-# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+ruby:
+  install:
+    - gemfile: Gemfile
+    
+commands:
+  - gem install bundler
+  - bundle install
+  - rake doc:yard
+  - cp -r doc $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,5 @@ build:
     - bundle install
     - bundle exec rake doc:yard
     - mkdir -p $READTHEDOCS_OUTPUT/html
-    - cp -r doc/ $READTHEDOCS_OUTPUT/html/
+    - cp -r doc/. $READTHEDOCS_OUTPUT/html/
     - ls -l $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    ruby: "2.7"    
+    ruby: "3.3"    
   commands:
     - gem install bundler
     - bundle install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,9 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    ruby: "3.3"
-    
-commands:
-  - gem install bundler
-  - bundle install
-  - rake doc:yard
-  - cp -r doc $READTHEDOCS_OUTPUT/html
+    ruby: "3.3"    
+  commands:
+    - gem install bundler
+    - bundle install
+    - rake doc:yard
+    - cp -r doc $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,4 @@ build:
     - bundle exec rake doc:yard
     - mkdir -p $READTHEDOCS_OUTPUT/html
     - cp -r doc/. $READTHEDOCS_OUTPUT/html/
-    - ls -l $READTHEDOCS_OUTPUT/html
+    

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,5 @@ build:
     - bundle install
     - bundle exec rake doc:yard
     - mkdir -p $READTHEDOCS_OUTPUT/html
-    - cp -r doc $READTHEDOCS_OUTPUT/html
+    - cp -r doc/ $READTHEDOCS_OUTPUT/html/
     - ls -l $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,5 @@ build:
     - gem install bundler -v 2.3
     - bundle install
     - bundle exec rake doc:yard
+    - mkdir -p $READTHEDOCS_OUTPUT/html
     - cp -r doc $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,6 @@ build:
   os: ubuntu-22.04
   tools:
     ruby: "3.3"
-
-ruby:
-  install:
-    - gemfile: Gemfile
     
 commands:
   - gem install bundler

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,5 @@ build:
   commands:
     - gem install bundler -v 2.3
     - bundle install
-    - rake doc:yard
+    - bundle exec rake doc:yard
     - cp -r doc $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    ruby: "3.3"    
+    ruby: "2.7"    
   commands:
     - gem install bundler
     - bundle install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,4 @@ build:
     - bundle exec rake doc:yard
     - mkdir -p $READTHEDOCS_OUTPUT/html
     - cp -r doc $READTHEDOCS_OUTPUT/html
+    - ls -l $READTHEDOCS_OUTPUT/html

--- a/lib/tree/utils/hash_converter.rb
+++ b/lib/tree/utils/hash_converter.rb
@@ -106,7 +106,8 @@ module Tree
 
           root, children = hash.first
 
-          raise ArgumentError, 'Invalid child. Must be nil or hash.' unless [Hash, NilClass].include?(children.class)
+          raise ArgumentError, 'Invalid child. Must be nil or hash.'\
+                                unless [Hash, NilClass].any? { |c| children.is_a? c }
 
           node = new(*root)
           node.add_from_hash(children) unless children.nil?


### PR DESCRIPTION
Added a [readthedocs][] configuration to host a secondary copy of the documentation there.

[readthedocs]: https://rubytree.readthedocs.io/en/