### PR TITLE
Add RubyGems trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@
 # rubygems.org (Manage Gem > Trusted Publishers), pointing at this
 # repository and this workflow file name.
 #
+# Tag push triggers cannot be scoped to a branch directly (a tag ref has no
+# branch of its own), so a release tag pushed from anywhere still fires this
+# workflow. The "Verify tag is reachable from master" step guards against
+# that: it fails the job before anything is published if the tagged commit
+# is not on master, so an accidental release tag on another branch is
+# harmless.
+#
 # This runs as a Github Action.
 
 name: Release to RubyGems
@@ -27,6 +34,15 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is reachable from master
+        run: |
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::Tag $GITHUB_REF_NAME (commit $GITHUB_SHA) is not on master. Refusing to publish."
+            exit 1
+          fi
 
       - name: Setup Ruby and bundler dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+# Publish the RubyTree gem to RubyGems.org on a release tag.
+#
+# Uses RubyGems trusted publishing (OIDC) instead of a stored API key, so
+# there is no long-lived RubyGems credential held by this repository or by
+# any maintainer's machine for automated releases.
+#
+# A Trusted Publisher must be configured for the `rubytree` gem at
+# rubygems.org (Manage Gem > Trusted Publishers), pointing at this
+# repository and this workflow file name.
+#
+# This runs as a Github Action.
+
+name: Release to RubyGems
+
+on:
+  push:
+    tags:
+      - "R*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby and bundler dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ".ruby-version"
+
+      - name: Configure RubyGems trusted-publishing credentials
+        uses: rubygems/configure-rubygems-credentials@main
+
+      - name: Build gem package
+        run: bundle exec rake gem:package
+
+      - name: Push to RubyGems.org
+        run: gem push pkg/*.gem


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml`, a tag-triggered (`R*`) workflow that publishes `rubytree` to RubyGems.org using trusted publishing (OIDC) instead of a stored API key
- Guard the workflow so it refuses to publish if the tagged commit isn't reachable from `master`, since tag-push triggers can't be scoped to a branch directly

## Context
RubyGems.org expired all legacy API keys after a CDN caching bug (GHSA-9j48-x3c3-mrp2) could replay one account's key to another request for up to an hour. This removes the need to store a long-lived RubyGems API key anywhere for future releases. A Trusted Publisher for `evolve75/RubyTree` / `release.yml` has already been configured on rubygems.org. The existing `rake gem:push` task (which also pushes to GitHub Packages) remains as a manual fallback.

## Test plan
- [x] `rake test:all` passes on this branch
- [x] `rake gem:package` builds the gem successfully
- [x] Workflow YAML validated
- [ ] End-to-end trusted-publishing verified on the next real tagged release (this PR itself does not trigger a publish — only a pushed `R*` tag does)