### PR TITLE
Bump json to patched version, fixing CVE-2026-54696 (v2.2.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubytree (2.2.0)
+    rubytree (2.2.1)
       json (~> 2.0, >= 2.19.9)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubytree (2.2.0)
-      json (~> 2.0, > 2.9)
+      json (~> 2.0, >= 2.19.9)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     date (3.4.1)
     diff-lcs (1.5.1)
     docile (1.4.1)
-    json (2.9.1)
+    json (2.21.1)
     language_server-protocol (3.17.0.3)
     parallel (1.26.3)
     parser (3.3.6.0)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 # History of Changes
 
+### 2.2.1 / 2026-07-24
+
+* Bump the `json` runtime dependency to 2.19.9+, fixing a heap buffer
+  overflow when generating to a streamed IO
+  ([CVE-2026-54696](https://github.com/ruby/json/security/advisories/GHSA-x2f5-4prf-w687)).
+
 ### 2.2.0 / 2026-02-06
 
 * Prevent cycles by rejecting attempts to add an ancestor as a child.

--- a/lib/tree/version.rb
+++ b/lib/tree/version.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Anupam Sengupta (anupamsg@gmail.com)
 #
-# Copyright (c) 2012-2024 Anupam Sengupta. All rights reserved.
+# Copyright (c) 2012-2026 Anupam Sengupta. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,5 +35,5 @@
 
 module Tree
   # Rubytree Package Version
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/rubytree.gemspec
+++ b/rubytree.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
                             '--main', 'README.md',
                             '--quiet']
 
-  s.add_runtime_dependency 'json', '~> 2.0', '> 2.9'
+  s.add_runtime_dependency 'json', '~> 2.0', '>= 2.19.9'
 
   # NOTE: Rake is added as a development and test dependency in the Gemfile.
   s.add_development_dependency 'bundler', '~> 2.3'


### PR DESCRIPTION
## Summary
- Bump the `json` runtime dependency's minimum constraint to `>= 2.19.9`, fixing [CVE-2026-54696 / GHSA-x2f5-4prf-w687](https://github.com/ruby/json/security/advisories/GHSA-x2f5-4prf-w687) (heap buffer overflow when generating to a streamed IO); `Gemfile.lock` resolves to 2.21.1
- Bump `Tree::VERSION` to `2.2.1`, add the `History.md` release note, and refresh the copyright year range in `lib/tree/version.rb`

## Context
`master`'s `Gemfile.lock` was resolving `json (2.9.1)`, which falls in the vulnerable range (2.9.0-2.19.8). The gemspec's existing `~> 2.0` upper bound already permitted the patched version, so no constraint widening was needed — just a lower-bound bump and a `bundle update json`.

This is intended as the first real end-to-end test of the trusted-publishing release workflow added in #129: once merged, we'll tag `R2.2.1` on `master` to trigger the OIDC publish to RubyGems.org, then cherry-pick both commits into `next`.

## Test plan
- [x] `rake test:all` passes (96 tests / 36 examples, 0 failures)
- [x] `rake gem:package` builds `rubytree-2.2.1.gem` successfully
- [x] `rake version` reports `rubytree-2.2.1.gem`
- [ ] End-to-end trusted-publishing verified once `R2.2.1` is tagged after merge