### PR TITLE
Bump actions/checkout to v7 to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Setup Ruby and bundler dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from `@v2` (ruby.yml, coveralls.yml) / `@v4` (release.yml) to `@v7.0.1`, resolving the "Node.js 20 is deprecated" warning GitHub Actions emits on every run for these actions
- No behavioral changes to our usage (plain checkout, one `fetch-depth: 0` usage in release.yml) -- reviewed the v5/v6/v7 changelogs and none introduce breaking changes relevant here

## Test plan
- [x] YAML validated for all three workflow files
- [ ] CI green on this PR (checkout itself is exercised by every job)