### PR TITLE
Bump actions/checkout to v7 to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Ruby and bundler dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -42,7 +42,7 @@ jobs:
     name: Quality Checks (Ruby 3.4)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from `@v4` to `@v7.0.1` across `tests.yml` (both jobs), `coverage.yml`, and `release.yml`, resolving the "Node.js 20 is deprecated" warning GitHub Actions emits on every run
- No behavioral changes to our usage -- reviewed the v5/v6/v7 changelogs, no breaking changes apply to our plain-checkout usage

## Test plan
- [x] YAML validated for all three workflow files
- [ ] CI green on this PR (checkout itself is exercised by every job)